### PR TITLE
[CLD-4661] Add internal GitLab pipeline for releasing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+# This will run on the internal gitlab
+# Will run only when have a tag pushed
+# Internal GitLab repo: https://git.internal.mattermost.com/mattermost/ci/mattermost-apps
+
+stages:
+  - build
+  - publish
+
+include:
+  - project: mattermost/ci/mattermost-apps
+    ref: main
+    file: private.yml
+
+variables:
+  IMAGE_TO_BUILD: cimg/node:16.1


### PR DESCRIPTION
#### Summary
Add the GitLab ci file that ensures the GitLab release pipeline is triggered.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4661